### PR TITLE
Create tests for index.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "author": "Microsoft",
     "scripts": {
         "start": "node index.js",
-        "dev": "nodemon"
+        "dev": "nodemon",
+        "test": "jest"
     },
     "dependencies": {
         "ejs": "^3.0.1",
@@ -16,6 +17,8 @@
     },
     "devDependencies": {
         "gulp": "^4.0.2",
-        "gulp-imagemin": "^7.1.0"
+        "gulp-imagemin": "^7.1.0",
+        "supertest": "^6.1.3",
+        "jest": "^27.0.6"
     }
 }

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1,0 +1,41 @@
+const request = require('supertest');
+const app = require('../index');
+const haikus = require('../haikus.json');
+
+describe('GET /', () => {
+  it('should return HTML response with haikus', async () => {
+    const response = await request(app).get('/');
+    expect(response.status).toBe(200);
+    expect(response.text).toContain('Haikus for June');
+    haikus.forEach(haiku => {
+      expect(response.text).toContain(haiku.text);
+      expect(response.text).toContain(haiku.image);
+    });
+  });
+});
+
+describe('GET /:id', () => {
+  haikus.forEach((haiku, index) => {
+    it(`should return HTML response with haiku ${index}`, async () => {
+      const response = await request(app).get(`/${index}`);
+      expect(response.status).toBe(200);
+      expect(response.text).toContain('Haikus for June');
+      expect(response.text).toContain(haiku.text);
+      expect(response.text).toContain(haiku.image);
+    });
+  });
+});
+
+describe('POST /', () => {
+  haikus.forEach((haiku, index) => {
+    it(`should return HTML response with haiku ${index}`, async () => {
+      const response = await request(app)
+        .post('/')
+        .send({ id: index });
+      expect(response.status).toBe(200);
+      expect(response.text).toContain('Haikus for June');
+      expect(response.text).toContain(haiku.text);
+      expect(response.text).toContain(haiku.image);
+    });
+  });
+});


### PR DESCRIPTION
Fixes #2

Add tests for `index.js` HTML responses using `supertest` and `jest`.

* **package.json**
  - Add `supertest` and `jest` as dev dependencies.
  - Add a test script to run tests using `jest`.

* **tests/index.test.js**
  - Import `supertest`, `app` from `index.js`, and `haikus` from `haikus.json`.
  - Write tests for the root endpoint to check HTML responses.
  - Write tests for the `/id` endpoint to check HTML responses for every element in `haikus.json`.
  - Write tests for the POST endpoint to check HTML responses.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/github-booth/haikus-for-june/issues/2?shareId=da41af93-82e2-47cc-ae27-3bef3882ae21).